### PR TITLE
Loading icon for the interview analyzing

### DIFF
--- a/src/pages/interview/detail/index.tsx
+++ b/src/pages/interview/detail/index.tsx
@@ -103,7 +103,7 @@ const InterviewDetails = () => {
           if (!haveAnalysis) {
             // If isDisableInterviewAnalysis false, toasts the user that the analysis is not ready yet
             if (!result.data.getUserInterviewMetaData.isDisableInterviewAnalysis) {
-              toast.error(
+              toast.loading(
                 'Analysis is not ready yet. Please try again later. It may take up to 30 minutes to process the video.',
                 {
                   duration: 10000,


### PR DESCRIPTION
Remove the red icon for this warning. Either totally remove the icon, or use some “loading” or  “waiting” icon. 